### PR TITLE
タスクを他のクライアントに送信するsocketのイベントを追加

### DIFF
--- a/chatapp/socket_event/index.js
+++ b/chatapp/socket_event/index.js
@@ -13,4 +13,9 @@ export default (io, socket) => {
   socket.on("publishEvent", (data) => {
     io.sockets.emit("publishEvent", data)
   })
+
+  // タスクメッセージを送信する
+  socket.on("publishTask", (data) => {
+    socket.broadcast.emit("publishTask", data)
+  })
 }


### PR DESCRIPTION
# socketのイベントの追加
- socketのイベントをsocket_event配下のindex.jsに新たに定義
- イベント名を[publishTask]とした 